### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/salinapooja12340038/89af2d42-0bb3-4ffa-9148-8f00a8c0c7fe/edacccec-c5f9-4b3c-b572-f410ae28d522/_apis/work/boardbadge/38528c29-f58f-4aa4-aed3-2839c5dd8705)](https://dev.azure.com/salinapooja12340038/89af2d42-0bb3-4ffa-9148-8f00a8c0c7fe/_boards/board/t/edacccec-c5f9-4b3c-b572-f410ae28d522/Microsoft.RequirementCategory)
 # azure-git


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#138](https://dev.azure.com/salinapooja12340038/89af2d42-0bb3-4ffa-9148-8f00a8c0c7fe/_workitems/edit/138). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.